### PR TITLE
added organizations table to organizations index page (to replace placeholder) -kz

### DIFF
--- a/frontend/src/main/components/Organizations/OrganizationsTable.js
+++ b/frontend/src/main/components/Organizations/OrganizationsTable.js
@@ -1,0 +1,61 @@
+import OurTable from "main/components/OurTable";
+// import { useBackendMutation } from "main/utils/useBackend";
+// import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/UCSBDateUtils"
+// import { useNavigate } from "react-router-dom";
+// import { hasRole } from "main/utils/currentUser";
+
+export default function OrganizationsTable({ organizations, _currentUser }) { // destructuring props (react convention) into individual parameters
+
+    // const navigate = useNavigate();
+
+    // const editCallback = (cell) => {
+    //     navigate(`/ucsbdates/edit/${cell.row.values.id}`)
+    // }
+
+    // Stryker disable all : hard to test for query caching
+    // const deleteMutation = useBackendMutation(
+    //     cellToAxiosParamsDelete,
+    //     { onSuccess: onDeleteSuccess },
+    //     ["/api/ucsbdates/all"]
+    // );
+    // Stryker enable all 
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    // const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
+
+    const columns = [
+        {
+            Header: 'Organization Code',
+            accessor: 'orgCode', // accessor is the "key" in the data
+        },
+        {
+            Header: 'Organization Translation (Abbreviated)',
+            accessor: 'orgTranslationShort',
+        },
+        {
+            Header: 'Organization Translation',
+            accessor: 'orgTranslation',
+        },
+        {
+            Header: 'Inactive?',
+            accessor: 'inactive',
+            accessor: (row, _rowIndex) => String(row.inactive) // hack needed for boolean values to show up
+   
+        }
+    ];
+
+    // const columnsIfAdmin = [
+    //     ...columns,
+    //     ButtonColumn("Edit", "primary", editCallback, "OrganizationTable"),
+    //     ButtonColumn("Delete", "danger", deleteCallback, "OrganizationTable")
+    // ];
+
+    // const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
+    const columnsToDisplay = columns;
+
+    return <OurTable
+        data={organizations}
+        columns={columnsToDisplay}
+        testid={"OrganizationsTable"}
+    />;
+};

--- a/frontend/src/main/pages/Organizations/OrganizationsIndexPage.js
+++ b/frontend/src/main/pages/Organizations/OrganizationsIndexPage.js
@@ -1,14 +1,29 @@
+import React from 'react'
+import { useBackend } from 'main/utils/useBackend'; // use prefix indicates a React Hook
+
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import OrganizationsTable from 'main/components/Organizations/OrganizationsTable';
+import { useCurrentUser } from 'main/utils/currentUser' // use prefix indicates a React Hook
 
 export default function OrganizationsIndexPage() {
+
+  const currentUser = useCurrentUser();
+
+  const { data: organizations, error: _error, status: _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      ["/api/UCSBOrganization/all"],
+            // Stryker disable next-line StringLiteral,ObjectLiteral : since "GET" is default, "" is an equivalent mutation
+            { method: "GET", url: "/api/UCSBOrganization/all" },
+      []
+    );
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Organizations</h1>
-        <p>
-          This is where the index page will go
-        </p>
+        <h1>UCSB Organizations</h1>
+        <OrganizationsTable organizations={organizations} currentUser={currentUser} />
       </div>
     </BasicLayout>
   )
-}
+} 


### PR DESCRIPTION
underneath the header on the Organizations Index page, instead of the placeholder text there is now a table with columns labeled corresponding to the organization database columns.

closes #16
