### PR TITLE
implemented delete buttons for organizations table -kz

### DIFF
--- a/frontend/src/main/components/Organizations/OrganizationsTable.js
+++ b/frontend/src/main/components/Organizations/OrganizationsTable.js
@@ -1,27 +1,39 @@
-import OurTable from "main/components/OurTable";
-// import { useBackendMutation } from "main/utils/useBackend";
-// import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/UCSBDateUtils"
+import OurTable, {ButtonColumn} from "main/components/OurTable";
+import { useBackendMutation } from "main/utils/useBackend";
+import { onDeleteSuccess } from "main/utils/UCSBDateUtils"
 // import { useNavigate } from "react-router-dom";
-// import { hasRole } from "main/utils/currentUser";
+import { hasRole } from "main/utils/currentUser";
 
-export default function OrganizationsTable({ organizations, _currentUser }) { // destructuring props (react convention) into individual parameters
 
-    // const navigate = useNavigate();
+export function cellToAxiosParamsDelete(cell) {
+    return {
+        url: "/api/UCSBOrganization",
+        method: "DELETE",
+        params: {
+            orgCode: cell.row.values.orgCode
+        }
+    }
+}
+
+
+export default function OrganizationsTable({ organizations, currentUser }) { // destructuring props (react convention) into individual parameters
+
+    // const navigate = useNavigate(); // for edit function
 
     // const editCallback = (cell) => {
     //     navigate(`/ucsbdates/edit/${cell.row.values.id}`)
     // }
 
     // Stryker disable all : hard to test for query caching
-    // const deleteMutation = useBackendMutation(
-    //     cellToAxiosParamsDelete,
-    //     { onSuccess: onDeleteSuccess },
-    //     ["/api/ucsbdates/all"]
-    // );
+    const deleteMutation = useBackendMutation(
+        cellToAxiosParamsDelete,
+        { onSuccess: onDeleteSuccess },
+        ["/api/UCSBOrganization/all"]
+    );
     // Stryker enable all 
 
     // Stryker disable next-line all : TODO try to make a good test for this
-    // const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
+    const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
 
     const columns = [
         {
@@ -46,15 +58,16 @@ export default function OrganizationsTable({ organizations, _currentUser }) { //
 
     const testid = "OrganizationsTable"
 
-    // const columnsIfAdmin = [
-    //     ...columns,
-    //     ButtonColumn("Edit", "primary", editCallback, "OrganizationTable"),
-    //     ButtonColumn("Delete", "danger", deleteCallback, "OrganizationTable")
-    // ];
+    const columnsIfAdmin = [
+        ...columns,
+        // ButtonColumn("Edit", "primary", editCallback, "OrganizationTable"),
+        // ButtonColumn("Delete", "danger", deleteCallback, "OrganizationTable") // from UCSBDates example
+        ButtonColumn("Delete", "danger", deleteCallback, testid) // from DiningCommons example
+        // ButtonColumn("Delete", "danger", deleteCallback, "OrganizationTable", "orgCode")
+    ];
 
-    // const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
-    const columnsToDisplay = columns;
-
+    const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
+    
     return <OurTable
         data={organizations}
         columns={columnsToDisplay}

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -236,6 +236,54 @@ describe("AppNavbar tests", () => {
         await waitFor( () => expect(getByTestId(/appnavbar-dining-commons-list/)).toBeInTheDocument() );
 
     });
+
+    test("renders the organizations menu correctly for a user", async () => {
+
+        const currentUser = currentUserFixtures.userOnly;
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        const doLogin = jest.fn();
+
+        const {getByTestId  } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(getByTestId("appnavbar-organizations-dropdown")).toBeInTheDocument());
+        const dropdown = getByTestId("appnavbar-organizations-dropdown");
+        const aElement = dropdown.querySelector("a");
+        expect(aElement).toBeInTheDocument();
+        aElement?.click();
+        await waitFor( () => expect(getByTestId("appnavbar-organizations-list")).toBeInTheDocument() );
+
+    });
+
+    test("renders the organizations menu correctly for an admin", async () => {
+
+        const currentUser = currentUserFixtures.adminUser;
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        const doLogin = jest.fn();
+
+        const {getByTestId  } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(getByTestId("appnavbar-organizations-dropdown")).toBeInTheDocument());
+        const dropdown = getByTestId("appnavbar-organizations-dropdown");
+        const aElement = dropdown.querySelector("a");
+        expect(aElement).toBeInTheDocument();
+        aElement?.click();
+        await waitFor( () => expect(getByTestId(/appnavbar-organizations-list/)).toBeInTheDocument() );
+
+    });
    
 });
 

--- a/frontend/src/tests/components/Organizations/OrganizationsTable.test.js
+++ b/frontend/src/tests/components/Organizations/OrganizationsTable.test.js
@@ -1,0 +1,127 @@
+import {  render } from "@testing-library/react";
+import { organizationsFixtures } from "fixtures/organizationsFixtures";
+import OrganizationsTable from "main/components/Organizations/OrganizationsTable";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("OrganizationsTable tests", () => {
+  const queryClient = new QueryClient();
+
+
+  test("renders without crashing for empty table with user not logged in", () => {
+    const currentUser = null;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <OrganizationsTable organizations={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+  test("renders without crashing for empty table for ordinary user", () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <OrganizationsTable organizations={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+
+  test("renders without crashing for empty table for admin", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <OrganizationsTable organizations={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+
+  test("Has the expected column headers and content for adminUser", () => {
+
+    const currentUser = currentUserFixtures.adminUser;
+
+    const { getByText, getByTestId } = render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <OrganizationsTable organizations={organizationsFixtures.threeOrganizations} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+
+    const expectedHeaders = ['Organization Code',  'Organization Translation (Abbreviated)', 'Organization Translation','Inactive?'];
+    const expectedFields = ['orgCode', 'orgTranslationShort','orgTranslation', 'inactive'];
+    const testId = "OrganizationsTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(getByTestId(`${testId}-cell-row-0-col-orgCode`)).toHaveTextContent("sky");
+    expect(getByTestId(`${testId}-cell-row-1-col-orgCode`)).toHaveTextContent("osli");
+    expect(getByTestId(`${testId}-cell-row-0-col-orgTranslationShort`)).toHaveTextContent("Skydiving Club");
+    expect(getByTestId(`${testId}-cell-row-1-col-orgTranslationShort`)).toHaveTextContent("Student Life");
+
+    // const editButton = getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    // expect(editButton).toBeInTheDocument();
+    // expect(editButton).toHaveClass("btn-primary");
+
+    const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+
+  });
+
+  // test("Edit button navigates to the edit page for admin user", async () => {
+
+  //   const currentUser = currentUserFixtures.adminUser;
+
+  //   const { getByTestId } = render(
+  //     <QueryClientProvider client={queryClient}>
+  //       <MemoryRouter>
+  //         <UCSBDatesTable organizations={ucsbDatesFixtures.threeOrganizations} currentUser={currentUser} />
+  //       </MemoryRouter>
+  //     </QueryClientProvider>
+
+  //   );
+
+  //   await waitFor(() => { expect(getByTestId(`UCSBDatesTable-cell-row-0-col-id`)).toHaveTextContent("1"); });
+
+  //   const editButton = getByTestId(`UCSBDatesTable-cell-row-0-col-Edit-button`);
+  //   expect(editButton).toBeInTheDocument();
+    
+  //   fireEvent.click(editButton);
+
+  //   await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/ucsbdates/edit/1'));
+
+  // });
+
+
+});
+

--- a/frontend/src/tests/pages/Organizations/OrganizationsIndexPage.test.js
+++ b/frontend/src/tests/pages/Organizations/OrganizationsIndexPage.test.js
@@ -1,4 +1,4 @@
-import { _fireEvent, render, waitFor } from "@testing-library/react"; // react testing library
+import { fireEvent, render, waitFor } from "@testing-library/react"; // react testing library
 import { QueryClient, QueryClientProvider } from "react-query"; // this library communicates between the frontend and the backend
 import { MemoryRouter } from "react-router-dom"; // simulates navigation from page to page
 import OrganizationsIndexPage from "main/pages/Organizations/OrganizationsIndexPage";
@@ -9,7 +9,7 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures"; // way for fro
 import { organizationsFixtures } from "fixtures/organizationsFixtures";
 import axios from "axios"; // i know this one
 import AxiosMockAdapter from "axios-mock-adapter"; // simulate http requests to backend
-import mockConsole from "jest-mock-console"; // simulates console logs and errors etc.
+import _mockConsole from "jest-mock-console"; // simulates console logs and errors etc.
 
 
 // check whether toast would have been produced
@@ -119,9 +119,9 @@ describe("OrganizationsIndexPage tests", () => {
         const queryClient = new QueryClient();
         axiosMock.onGet("/api/UCSBOrganization/all").timeout();
 
-        const restoreConsole = mockConsole();
+        // const restoreConsole = mockConsole(); // removed in frontend-testing-part-2
 
-        const { queryByTestId } = render(
+        const { queryByTestId, getByText } = render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
                     <OrganizationsIndexPage />
@@ -129,33 +129,39 @@ describe("OrganizationsIndexPage tests", () => {
             </QueryClientProvider>
         );
 
-        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
-        restoreConsole();
+        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); }); // changed to 3 in frontend-testing-part-2
+        // restoreConsole(); // removed in frontend-testing-part-2
+
+        const expectedHeaders = ['Organization Code',  'Organization Translation (Abbreviated)', 'Organization Translation','Inactive?'];
+    
+        expectedHeaders.forEach((headerText) => {
+            const header = getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
 
         expect(queryByTestId(`${testId}-cell-row-0-col-orgCode`)).not.toBeInTheDocument();
     });
 
-    /*
 
     test("test what happens when you click delete, admin", async () => {
         setupAdminUser();
 
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/ucsbdates/all").reply(200, ucsbDatesFixtures.threeDates);
-        axiosMock.onDelete("/api/ucsbdates").reply(200, "UCSBDate with id 1 was deleted");
+        axiosMock.onGet("/api/UCSBOrganization/all").reply(200, organizationsFixtures.threeOrganizations);
+        axiosMock.onDelete("/api/UCSBOrganization", {params: {orgCode:"sky"}}).reply(200, "Organization with orgCode sky was deleted");
 
 
         const { getByTestId } = render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
-                    <UCSBDatesIndexPage />
+                    <OrganizationsIndexPage />
                 </MemoryRouter>
             </QueryClientProvider>
         );
 
-        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
+        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-orgCode`)).toBeInTheDocument(); });
 
-       expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); 
+       expect(getByTestId(`${testId}-cell-row-0-col-orgCode`)).toHaveTextContent("sky"); 
 
 
         const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
@@ -163,10 +169,9 @@ describe("OrganizationsIndexPage tests", () => {
        
         fireEvent.click(deleteButton);
 
-        await waitFor(() => { expect(mockToast).toBeCalledWith("UCSBDate with id 1 was deleted") });
+        await waitFor(() => { expect(mockToast).toBeCalledWith("Organization with orgCode sky was deleted") });
 
     });
-    */
 
 });
 


### PR DESCRIPTION
- implemented delete column for organization table with working delete buttons
- implemented tests that ensure that delete column is displayed and works as expected
- (see issue acceptance criteria for more detail)
- with this PR i also brought stryker mutation testing coverage up to 100% for the organizations portion of the project
- this PR concludes my work on organization stuff for team03
- closes #15 