### PR TITLE
Nm add delete column to helprequest table

### DIFF
--- a/frontend/src/main/components/HelpRequests/HelpRequestsTable.js
+++ b/frontend/src/main/components/HelpRequests/HelpRequestsTable.js
@@ -50,7 +50,6 @@ export default function HelpRequestsTable({ helpRequests, currentUser }) {
         },
         {
             Header: 'Solved?',
-            accessor: 'solved',
             accessor: (row, _rowIndex) => String(row.solved) // hack needed for boolean values to show up
         }
     ];

--- a/frontend/src/main/components/HelpRequests/HelpRequestsTable.js
+++ b/frontend/src/main/components/HelpRequests/HelpRequestsTable.js
@@ -15,12 +15,15 @@ export function cellToAxiosParamsDelete(cell) {
 
 export default function HelpRequestsTable({ helpRequests, currentUser }) {
 
+    // Stryker disable all : hard to test for query caching
     const deleteMutation = useBackendMutation(
         cellToAxiosParamsDelete,
         { onSuccess: onDeleteSuccess },
         ["/api/HelpRequest/all"]
     );
+    // Stryker enable all
 
+    // Stryker disable next-line all : TODO try to make a good test for this
     const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
 
     const columns = [ 

--- a/frontend/src/main/components/HelpRequests/HelpRequestsTable.js
+++ b/frontend/src/main/components/HelpRequests/HelpRequestsTable.js
@@ -1,7 +1,27 @@
-import OurTable from "main/components/OurTable";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+import { useBackendMutation } from "main/utils/useBackend";
+import { onDeleteSuccess } from "main/utils/UCSBDateUtils"
+import { hasRole } from "main/utils/currentUser";
 
-export default function HelpRequestsTable({ helpRequests, _currentUser }) {
+export function cellToAxiosParamsDelete(cell) {
+    return {
+        url: "/api/HelpRequest",
+        method: "DELETE",
+        params: {
+            id: cell.row.values.id
+        }
+    }
+}
 
+export default function HelpRequestsTable({ helpRequests, currentUser }) {
+
+    const deleteMutation = useBackendMutation(
+        cellToAxiosParamsDelete,
+        { onSuccess: onDeleteSuccess },
+        ["/api/HelpRequest/all"]
+    );
+
+    const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
 
     const columns = [ 
         {
@@ -35,13 +55,16 @@ export default function HelpRequestsTable({ helpRequests, _currentUser }) {
         }
     ];
 
-    const testid = "HelpRequestsTable";
+    const columnsIfAdmin = [
+        ...columns,
+        ButtonColumn("Delete", "danger", deleteCallback, "HelpRequestsTable")
+    ];
 
-    const columnsToDisplay = columns;
+    const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
 
     return <OurTable
         data={helpRequests}
         columns={columnsToDisplay}
-        testid={testid}
+        testid={"HelpRequestsTable"}
     />;
 };

--- a/frontend/src/main/components/HelpRequests/HelpRequestsTable.js
+++ b/frontend/src/main/components/HelpRequests/HelpRequestsTable.js
@@ -25,8 +25,9 @@ export default function HelpRequestsTable({ helpRequests, currentUser }) {
 
     const columns = [ 
         {
-            Header: 'id',
-            accessor: 'id', // accessor is the "key" in the data
+            Header: 'Id',
+            id: 'id',
+            accessor: (row, _rowIndex) => String(row.id)
         },
         {
             Header: 'Requester Email',
@@ -50,6 +51,7 @@ export default function HelpRequestsTable({ helpRequests, currentUser }) {
         },
         {
             Header: 'Solved?',
+            id: 'isSolved',
             accessor: (row, _rowIndex) => String(row.solved) // hack needed for boolean values to show up
         }
     ];

--- a/frontend/src/tests/components/HelpRequests/HelpRequestsTable.test.js
+++ b/frontend/src/tests/components/HelpRequests/HelpRequestsTable.test.js
@@ -1,0 +1,125 @@
+// import { fireEvent, render, waitFor } from "@testing-library/react";
+import {  render } from "@testing-library/react";
+import { helpRequestsFixtures } from "fixtures/helpRequestsFixtures";
+import HelpRequestsTable from "main/components/HelpRequests/HelpRequestsTable"
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("HelpRequestsTable tests", () => {
+  const queryClient = new QueryClient();
+
+
+  test("renders without crashing for empty table with user not logged in", () => {
+    const currentUser = null;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestsTable helpRequests={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+  test("renders without crashing for empty table for ordinary user", () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestsTable helpRequests={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+
+  test("renders without crashing for empty table for admin", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestsTable helpRequests={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+
+  test("Has the expected colum headers and content for adminUser", () => {
+
+    const currentUser = currentUserFixtures.adminUser;
+
+    const { getByText, getByTestId } = render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestsTable helpRequests={helpRequestsFixtures.threeRequests} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    const expectedHeaders = ['Id', 'Requester Email', 'Team ID', 'Table or Breakout Room?', 'Time of Request', 'Explanation', 'Solved?'];
+
+    const expectedFields = ['id', 'requesterEmail', 'teamId', 'tableOrBreakoutRoom', 'requestTime', 'explanation', 'isSolved'];
+    const testId = "HelpRequestsTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+
+    // const editButton = getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    // expect(editButton).toBeInTheDocument();
+    // expect(editButton).toHaveClass("btn-primary");
+
+    const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+
+  });
+
+//   test("Edit button navigates to the edit page for admin user", async () => {
+
+//     const currentUser = currentUserFixtures.adminUser;
+
+//     const { getByTestId } = render(
+//       <QueryClientProvider client={queryClient}>
+//         <MemoryRouter>
+//           <MenuItemsTable menuItems={menuItemsFixtures.threeMenuItems} currentUser={currentUser} />
+//         </MemoryRouter>
+//       </QueryClientProvider>
+
+//     );
+
+//     await waitFor(() => { expect(getByTestId(`MenuItemsTable-cell-row-0-col-id`)).toHaveTextContent("1"); });
+
+//     const editButton = getByTestId(`MenuItemsTable-cell-row-0-col-Edit-button`);
+//     expect(editButton).toBeInTheDocument();
+    
+//     fireEvent.click(editButton);
+
+//     await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/menuitems/edit/1'));
+
+//   });
+
+});
+

--- a/frontend/src/tests/pages/HelpRequests/HelpRequestsIndexPage.test.js
+++ b/frontend/src/tests/pages/HelpRequests/HelpRequestsIndexPage.test.js
@@ -9,7 +9,7 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import { helpRequestsFixtures } from "fixtures/helpRequestsFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import mockConsole from "jest-mock-console";
+import _mockConsole from "jest-mock-console";
 
 
 const mockToast = jest.fn();
@@ -118,9 +118,8 @@ describe("HelpRequestsIndexPage tests", () => {
         const queryClient = new QueryClient();
         axiosMock.onGet("/api/HelpRequest/all").timeout();
 
-        const restoreConsole = mockConsole();
 
-        const { queryByTestId } = render(
+        const { queryByTestId, getByText } = render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
                     <HelpRequestsIndexPage />
@@ -129,7 +128,14 @@ describe("HelpRequestsIndexPage tests", () => {
         );
 
         await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
-        restoreConsole();
+        // restoreConsole();
+
+        const expectedHeaders = ['Id', 'Requester Email', 'Team ID', 'Table or Breakout Room?', 'Time of Request', 'Explanation', 'Solved?']
+        
+        expectedHeaders.forEach((headerText) => {
+            const header = getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
 
         expect(queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
     });
@@ -139,7 +145,7 @@ describe("HelpRequestsIndexPage tests", () => {
 
         const queryClient = new QueryClient();
         axiosMock.onGet("/api/HelpRequest/all").reply(200, helpRequestsFixtures.threeRequests);
-        axiosMock.onDelete("/api/HelpRequest").reply(200, "HelpRequest with id 1 was deleted");
+        axiosMock.onDelete("/api/HelpRequest", {params: {id: "1"}}).reply(200, "HelpRequest with id 1 was deleted");
 
 
         const { getByTestId } = render(

--- a/frontend/src/tests/pages/HelpRequests/HelpRequestsIndexPage.test.js
+++ b/frontend/src/tests/pages/HelpRequests/HelpRequestsIndexPage.test.js
@@ -134,6 +134,35 @@ describe("HelpRequestsIndexPage tests", () => {
         expect(queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
     });
 
+    test("test what happens when you click delete, admin", async () => {
+        setupAdminUser();
+
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/HelpRequest/all").reply(200, helpRequestsFixtures.threeRequests);
+        axiosMock.onDelete("/api/HelpRequest").reply(200, "HelpRequest with id 1 was deleted");
+
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <HelpRequestsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
+
+       expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); 
+
+
+        const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+        expect(deleteButton).toBeInTheDocument();
+       
+        fireEvent.click(deleteButton);
+
+        await waitFor(() => { expect(mockToast).toBeCalledWith("HelpRequest with id 1 was deleted") });
+
+    });
 
 });
 


### PR DESCRIPTION
Delete column added to HelpRequest table. Testing expanded to include the Delete button. Test coverage and mutation testing accounted for.

Closes #36 